### PR TITLE
fix(ci): trigger release workflow only on release PR merge

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,17 +1,21 @@
 name: Release-plz Release
 
 on:
-    push:
+    pull_request:
+        types: [closed]
         branches:
             - master
 
+# Prevent duplicate release runs if the event fires more than once.
 concurrency:
-    group: release-plz-release-${{ github.ref }}
+    group: release-plz-release-${{ github.event.pull_request.number }}
     cancel-in-progress: false
 
 jobs:
     release-plz-release:
         name: Release-plz release
+        # Only run when the release PR (labelled "release" by release-plz) is merged.
+        if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'release')
         runs-on: ubuntu-latest
         permissions:
             contents: write


### PR DESCRIPTION
Previously the release workflow ran on every push to master, which caused unnecessary publish attempts on non-release commits.

Changed trigger from 'push' to 'pull_request: types: [closed]' and added a job condition that checks both that the PR was merged and that it carries the 'release' label (applied automatically by release-plz via pr_labels in release-plz.toml). This ensures the release step only fires when an actual release PR is merged.

Restored the concurrency guard (scoped to PR number) to prevent duplicate runs if the closed event fires more than once.