### PR TITLE
fix(api): address API consistency and usability issues across public surface

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -31,6 +31,14 @@ pub trait QueueClient: Send + Sync {
     ) -> Result<Vec<MessageId>, QueueError>;
 
     /// Receive single message from queue
+    ///
+    /// Returns the next available message without regard to session ordering.
+    ///
+    /// # Note
+    ///
+    /// For session-ordered processing (where messages within a session must be
+    /// handled strictly in order), use [`accept_session`](QueueClient::accept_session)
+    /// instead and call `receive_message` on the returned [`SessionClient`].
     async fn receive_message(
         &self,
         queue: &QueueName,
@@ -59,6 +67,15 @@ pub trait QueueClient: Send + Sync {
     ) -> Result<(), QueueError>;
 
     /// Accept session for ordered processing
+    ///
+    /// Acquires an exclusive lock on the specified session and returns a
+    /// [`SessionClient`] that delivers messages from that session in FIFO order.
+    ///
+    /// # Note
+    ///
+    /// For unordered message consumption (no session guarantee required), use
+    /// [`receive_message`](QueueClient::receive_message) directly, which is
+    /// faster and does not require a session lock.
     async fn accept_session(
         &self,
         queue: &QueueName,

--- a/src/client_tests.rs
+++ b/src/client_tests.rs
@@ -328,10 +328,7 @@ async fn test_queue_provider_send_message<P: QueueProvider>(provider: &P, queue:
 async fn test_queue_provider_session_support<P: QueueProvider>(provider: &P) {
     let support = provider.supports_sessions();
     assert!(
-        matches!(
-            support,
-            SessionSupport::Native | SessionSupport::Emulated | SessionSupport::Unsupported
-        ),
+        matches!(support, SessionSupport::Native | SessionSupport::Emulated),
         "Should return valid session support level"
     );
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -90,7 +90,6 @@ impl QueueError {
     /// Get suggested retry delay
     pub fn retry_after(&self) -> Option<Duration> {
         match self {
-            Self::InvalidReceipt { .. } => None,
             Self::SessionLocked { .. } => Some(Duration::seconds(5)),
             Self::Timeout { .. } => Some(Duration::seconds(1)),
             Self::ConnectionFailed { .. } => Some(Duration::seconds(5)),

--- a/src/error.rs
+++ b/src/error.rs
@@ -10,8 +10,11 @@ pub enum QueueError {
     #[error("Queue not found: {queue_name}")]
     QueueNotFound { queue_name: String },
 
-    #[error("Message not found or receipt expired: {receipt}")]
+    #[error("Message not found: {receipt}")]
     MessageNotFound { receipt: String },
+
+    #[error("Invalid or expired receipt handle: {receipt}")]
+    InvalidReceipt { receipt: String },
 
     #[error("Session '{session_id}' is locked until {locked_until}")]
     SessionLocked {
@@ -63,6 +66,7 @@ impl QueueError {
         match self {
             Self::QueueNotFound { .. } => false,
             Self::MessageNotFound { .. } => false,
+            Self::InvalidReceipt { .. } => false,
             Self::SessionLocked { .. } => true,
             Self::SessionNotFound { .. } => false,
             Self::Timeout { .. } => true,
@@ -86,6 +90,7 @@ impl QueueError {
     /// Get suggested retry delay
     pub fn retry_after(&self) -> Option<Duration> {
         match self {
+            Self::InvalidReceipt { .. } => None,
             Self::SessionLocked { .. } => Some(Duration::seconds(5)),
             Self::Timeout { .. } => Some(Duration::seconds(1)),
             Self::ConnectionFailed { .. } => Some(Duration::seconds(5)),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,8 +42,11 @@ pub use provider::{
 };
 pub use providers::nats::NatsConfig;
 pub use providers::rabbitmq::RabbitMqConfig;
-pub use providers::{AzureAuthMethod, AzureError, AzureServiceBusProvider, AzureSessionProvider, AwsError, AwsSessionProvider, AwsSqsProvider,
-    InMemoryProvider, InMemorySessionProvider, NatsError, NatsProvider, NatsSessionProvider,
+pub use providers::{
+    AzureAuthMethod, AzureError, AzureServiceBusProvider, AzureSessionProvider,
+    AwsError, AwsSessionProvider, AwsSqsProvider,
+    InMemoryProvider, InMemorySessionProvider,
+    NatsError, NatsProvider, NatsSessionProvider,
     RabbitMqError, RabbitMqProvider, RabbitMqSessionProvider,
 };
 pub use sessions::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,11 +43,10 @@ pub use provider::{
 pub use providers::nats::NatsConfig;
 pub use providers::rabbitmq::RabbitMqConfig;
 pub use providers::{
-    AzureAuthMethod, AzureError, AzureServiceBusProvider, AzureSessionProvider,
-    AwsError, AwsSessionProvider, AwsSqsProvider,
-    InMemoryProvider, InMemorySessionProvider,
-    NatsError, NatsProvider, NatsSessionProvider,
-    RabbitMqError, RabbitMqProvider, RabbitMqSessionProvider,
+    AwsError, AwsSessionProvider, AwsSqsProvider, AzureAuthMethod, AzureError,
+    AzureServiceBusProvider, AzureSessionProvider, InMemoryProvider, InMemorySessionProvider,
+    NatsError, NatsProvider, NatsSessionProvider, RabbitMqError, RabbitMqProvider,
+    RabbitMqSessionProvider,
 };
 pub use sessions::{
     CompositeKeyStrategy, FallbackStrategy, NoOrderingStrategy, SessionAffinity,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,8 +34,7 @@ pub use client::{
 };
 pub use error::{ConfigurationError, QueueError, SerializationError, ValidationError};
 pub use message::{
-    Message, MessageId, QueueName, ReceiptHandle, ReceiveOptions, ReceivedMessage, SendOptions,
-    SessionId, Timestamp,
+    Message, MessageId, QueueName, ReceiptHandle, ReceivedMessage, SessionId, Timestamp,
 };
 pub use provider::{
     AwsSqsConfig, AzureServiceBusConfig, InMemoryConfig, ProviderConfig, ProviderType, QueueConfig,
@@ -43,10 +42,9 @@ pub use provider::{
 };
 pub use providers::nats::NatsConfig;
 pub use providers::rabbitmq::RabbitMqConfig;
-pub use providers::{
-    AzureAuthMethod, AzureServiceBusProvider, AzureSessionProvider, InMemoryProvider,
-    InMemorySessionProvider, NatsError, NatsProvider, NatsSessionProvider, RabbitMqError,
-    RabbitMqProvider, RabbitMqSessionProvider,
+pub use providers::{AzureAuthMethod, AzureError, AzureServiceBusProvider, AzureSessionProvider, AwsError, AwsSessionProvider, AwsSqsProvider,
+    InMemoryProvider, InMemorySessionProvider, NatsError, NatsProvider, NatsSessionProvider,
+    RabbitMqError, RabbitMqProvider, RabbitMqSessionProvider,
 };
 pub use sessions::{
     CompositeKeyStrategy, FallbackStrategy, NoOrderingStrategy, SessionAffinity,

--- a/src/lib_tests.rs
+++ b/src/lib_tests.rs
@@ -44,7 +44,7 @@ fn test_message_builder() {
         .with_session_id(session_id.clone())
         .with_attribute("key".to_string(), "value".to_string())
         .with_correlation_id("corr-123".to_string())
-        .with_ttl(Duration::minutes(30));
+        .with_time_to_live(Duration::minutes(30));
 
     assert_eq!(message.session_id, Some(session_id));
     assert_eq!(message.attributes.get("key"), Some(&"value".to_string()));

--- a/src/message.rs
+++ b/src/message.rs
@@ -284,7 +284,7 @@ impl Message {
     }
 
     /// Add time-to-live for message expiration
-    pub fn with_ttl(mut self, ttl: Duration) -> Self {
+    pub fn with_time_to_live(mut self, ttl: Duration) -> Self {
         self.time_to_live = Some(ttl);
         self
     }

--- a/src/message_tests.rs
+++ b/src/message_tests.rs
@@ -10,7 +10,7 @@ fn test_message_builder() {
         .with_session_id(session_id.clone())
         .with_attribute("key".to_string(), "value".to_string())
         .with_correlation_id("corr-123".to_string())
-        .with_ttl(Duration::minutes(30));
+        .with_time_to_live(Duration::minutes(30));
 
     assert_eq!(message.session_id, Some(session_id));
     assert_eq!(message.attributes.get("key"), Some(&"value".to_string()));

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -117,6 +117,9 @@ fn default_auth_method() -> crate::providers::AzureAuthMethod {
 pub struct AwsSqsConfig {
     pub region: String,
     pub access_key_id: Option<String>,
+    /// AWS secret access key. Not serialized to prevent accidental exposure in
+    /// config files or logs; must be supplied at runtime (e.g. from an
+    /// environment variable or secrets manager).
     #[serde(skip)]
     pub secret_access_key: Option<String>,
     pub use_fifo_queues: bool,

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -63,8 +63,6 @@ pub enum SessionSupport {
     Native,
     /// Provider emulates sessions via other mechanisms (AWS SQS FIFO)
     Emulated,
-    /// Provider cannot support session ordering
-    Unsupported,
 }
 
 /// Configuration for queue client initialization
@@ -119,6 +117,7 @@ fn default_auth_method() -> crate::providers::AzureAuthMethod {
 pub struct AwsSqsConfig {
     pub region: String,
     pub access_key_id: Option<String>,
+    #[serde(skip)]
     pub secret_access_key: Option<String>,
     pub use_fifo_queues: bool,
 }

--- a/src/providers/aws.rs
+++ b/src/providers/aws.rs
@@ -294,7 +294,7 @@ impl AwsError {
                 message: msg,
             },
             Self::QueueNotFound(queue) => QueueError::QueueNotFound { queue_name: queue },
-            Self::InvalidReceipt(receipt) => QueueError::MessageNotFound { receipt },
+            Self::InvalidReceipt(receipt) => QueueError::InvalidReceipt { receipt },
             Self::MessageTooLarge { size, max_size } => {
                 QueueError::MessageTooLarge { size, max_size }
             }
@@ -1410,7 +1410,7 @@ impl QueueProvider for AwsSqsProvider {
         let parts: Vec<&str> = handle_str.split('|').collect();
 
         if parts.len() != 2 {
-            return Err(QueueError::MessageNotFound {
+            return Err(QueueError::InvalidReceipt {
                 receipt: handle_str.to_string(),
             });
         }
@@ -1448,7 +1448,7 @@ impl QueueProvider for AwsSqsProvider {
         let parts: Vec<&str> = handle_str.split('|').collect();
 
         if parts.len() != 2 {
-            return Err(QueueError::MessageNotFound {
+            return Err(QueueError::InvalidReceipt {
                 receipt: handle_str.to_string(),
             });
         }
@@ -2089,7 +2089,7 @@ impl SessionProvider for AwsSessionProvider {
         let parts: Vec<&str> = handle_str.split('|').collect();
 
         if parts.len() != 2 {
-            return Err(QueueError::MessageNotFound {
+            return Err(QueueError::InvalidReceipt {
                 receipt: handle_str.to_string(),
             });
         }
@@ -2118,7 +2118,7 @@ impl SessionProvider for AwsSessionProvider {
         let parts: Vec<&str> = handle_str.split('|').collect();
 
         if parts.len() != 2 {
-            return Err(QueueError::MessageNotFound {
+            return Err(QueueError::InvalidReceipt {
                 receipt: handle_str.to_string(),
             });
         }

--- a/src/providers/aws_tests.rs
+++ b/src/providers/aws_tests.rs
@@ -239,7 +239,7 @@ mod error_handling_tests {
 
         assert!(matches!(
             queue_error,
-            crate::error::QueueError::MessageNotFound { .. }
+            crate::error::QueueError::InvalidReceipt { .. }
         ));
     }
 }

--- a/src/providers/azure.rs
+++ b/src/providers/azure.rs
@@ -175,7 +175,7 @@ impl AzureError {
                 code: "ServiceBusError".to_string(),
                 message: msg,
             },
-            Self::MessageLockLost(msg) => QueueError::MessageNotFound { receipt: msg },
+            Self::MessageLockLost(msg) => QueueError::InvalidReceipt { receipt: msg },
             Self::SessionLockLost(session_id) => QueueError::SessionNotFound { session_id },
             Self::ConfigurationError(msg) => {
                 QueueError::ConfigurationError(ConfigurationError::Invalid { message: msg })
@@ -1008,7 +1008,7 @@ impl QueueProvider for AzureServiceBusProvider {
         let (lock_token, queue_name) =
             lock_tokens
                 .get(receipt.handle())
-                .ok_or_else(|| QueueError::MessageNotFound {
+                .ok_or_else(|| QueueError::InvalidReceipt {
                     receipt: receipt.handle().to_string(),
                 })?;
 
@@ -1047,7 +1047,7 @@ impl QueueProvider for AzureServiceBusProvider {
             }
             StatusCode::GONE | StatusCode::NOT_FOUND => {
                 // Lock expired or message already processed
-                Err(QueueError::MessageNotFound {
+                Err(QueueError::InvalidReceipt {
                     receipt: receipt.handle().to_string(),
                 })
             }
@@ -1068,7 +1068,7 @@ impl QueueProvider for AzureServiceBusProvider {
         let (lock_token, queue_name) =
             lock_tokens
                 .get(receipt.handle())
-                .ok_or_else(|| QueueError::MessageNotFound {
+                .ok_or_else(|| QueueError::InvalidReceipt {
                     receipt: receipt.handle().to_string(),
                 })?;
 
@@ -1109,7 +1109,7 @@ impl QueueProvider for AzureServiceBusProvider {
             }
             StatusCode::GONE | StatusCode::NOT_FOUND => {
                 // Lock expired or message already processed
-                Err(QueueError::MessageNotFound {
+                Err(QueueError::InvalidReceipt {
                     receipt: receipt.handle().to_string(),
                 })
             }
@@ -1134,7 +1134,7 @@ impl QueueProvider for AzureServiceBusProvider {
         let (lock_token, queue_name) =
             lock_tokens
                 .get(receipt.handle())
-                .ok_or_else(|| QueueError::MessageNotFound {
+                .ok_or_else(|| QueueError::InvalidReceipt {
                     receipt: receipt.handle().to_string(),
                 })?;
 
@@ -1182,7 +1182,7 @@ impl QueueProvider for AzureServiceBusProvider {
             }
             StatusCode::GONE | StatusCode::NOT_FOUND => {
                 // Lock expired or message already processed
-                Err(QueueError::MessageNotFound {
+                Err(QueueError::InvalidReceipt {
                     receipt: receipt.handle().to_string(),
                 })
             }

--- a/src/providers/azure_tests.rs
+++ b/src/providers/azure_tests.rs
@@ -288,8 +288,8 @@ mod error_tests {
         let azure_err = AzureError::MessageLockLost("receipt-123".to_string());
         let queue_err = azure_err.to_queue_error();
         assert!(
-            matches!(queue_err, QueueError::MessageNotFound { .. }),
-            "Should map to MessageNotFound"
+            matches!(queue_err, QueueError::InvalidReceipt { .. }),
+            "Should map to InvalidReceipt"
         );
 
         // Session lock lost

--- a/src/providers/memory.rs
+++ b/src/providers/memory.rs
@@ -509,7 +509,7 @@ impl QueueProvider for InMemoryProvider {
                 // Check if receipt is expired
                 if inflight.lock_expires_at <= now {
                     queue.in_flight.remove(receipt.handle());
-                    return Err(QueueError::MessageNotFound {
+                    return Err(QueueError::InvalidReceipt {
                         receipt: receipt.handle().to_string(),
                     });
                 }
@@ -521,7 +521,7 @@ impl QueueProvider for InMemoryProvider {
         }
 
         // Receipt not found in any queue
-        Err(QueueError::MessageNotFound {
+        Err(QueueError::InvalidReceipt {
             receipt: receipt.handle().to_string(),
         })
     }
@@ -535,7 +535,7 @@ impl QueueProvider for InMemoryProvider {
             if let Some(inflight) = queue.in_flight.remove(receipt.handle()) {
                 // Check if receipt is expired
                 if inflight.lock_expires_at <= now {
-                    return Err(QueueError::MessageNotFound {
+                    return Err(QueueError::InvalidReceipt {
                         receipt: receipt.handle().to_string(),
                     });
                 }
@@ -556,7 +556,7 @@ impl QueueProvider for InMemoryProvider {
         }
 
         // Receipt not found in any queue
-        Err(QueueError::MessageNotFound {
+        Err(QueueError::InvalidReceipt {
             receipt: receipt.handle().to_string(),
         })
     }
@@ -843,7 +843,7 @@ impl SessionProvider for InMemorySessionProvider {
             }
         }
 
-        Err(QueueError::MessageNotFound {
+        Err(QueueError::InvalidReceipt {
             receipt: receipt.handle().to_string(),
         })
     }
@@ -890,7 +890,7 @@ impl SessionProvider for InMemorySessionProvider {
             }
         }
 
-        Err(QueueError::MessageNotFound {
+        Err(QueueError::InvalidReceipt {
             receipt: receipt.handle().to_string(),
         })
     }
@@ -928,7 +928,7 @@ impl SessionProvider for InMemorySessionProvider {
             }
         }
 
-        Err(QueueError::MessageNotFound {
+        Err(QueueError::InvalidReceipt {
             receipt: receipt.handle().to_string(),
         })
     }

--- a/src/providers/memory_tests.rs
+++ b/src/providers/memory_tests.rs
@@ -144,7 +144,7 @@ mod data_structures {
     #[test]
     fn test_stored_message_with_ttl() {
         let ttl = Duration::seconds(60);
-        let message = Message::new(Bytes::from("test body")).with_ttl(ttl);
+        let message = Message::new(Bytes::from("test body")).with_time_to_live(ttl);
         let message_id = MessageId::new();
         let config = InMemoryConfig::default();
 
@@ -1027,7 +1027,7 @@ mod ttl_and_dlq {
         let queue_name = QueueName::new("ttl-test".to_string()).unwrap();
 
         // Send message with short TTL (2 seconds)
-        let msg = Message::new(Bytes::from("Expires soon")).with_ttl(Duration::seconds(2));
+        let msg = Message::new(Bytes::from("Expires soon")).with_time_to_live(Duration::seconds(2));
 
         provider.send_message(&queue_name, &msg).await.unwrap();
 
@@ -1064,7 +1064,7 @@ mod ttl_and_dlq {
 
         // Send two messages: one with TTL, one without
         let msg_with_ttl =
-            Message::new(Bytes::from("Has TTL")).with_ttl(Duration::milliseconds(500));
+            Message::new(Bytes::from("Has TTL")).with_time_to_live(Duration::milliseconds(500));
         let msg_without_ttl = Message::new(Bytes::from("No TTL"));
 
         provider

--- a/src/providers/memory_tests.rs
+++ b/src/providers/memory_tests.rs
@@ -698,7 +698,7 @@ mod acknowledgment {
 
     /// Verify that completing with an invalid receipt handle returns an error.
     ///
-    /// Assertion #6: Invalid receipt handle returns MessageNotFound error.
+    /// Assertion #6: Invalid receipt handle returns InvalidReceipt error.
     #[tokio::test]
     async fn test_complete_with_invalid_receipt_returns_error() {
         let provider = InMemoryProvider::default();
@@ -715,10 +715,10 @@ mod acknowledgment {
 
         assert!(result.is_err(), "Invalid receipt should return error");
         match result.unwrap_err() {
-            QueueError::MessageNotFound { .. } => {
+            QueueError::InvalidReceipt { .. } => {
                 // Expected error
             }
-            other => panic!("Expected MessageNotFound, got {:?}", other),
+            other => panic!("Expected InvalidReceipt, got {:?}", other),
         }
     }
 
@@ -752,10 +752,10 @@ mod acknowledgment {
 
         assert!(result.is_err(), "Expired receipt should return error");
         match result.unwrap_err() {
-            QueueError::MessageNotFound { .. } => {
+            QueueError::InvalidReceipt { .. } => {
                 // Expected error
             }
-            other => panic!("Expected MessageNotFound, got {:?}", other),
+            other => panic!("Expected InvalidReceipt, got {:?}", other),
         }
     }
 
@@ -849,10 +849,10 @@ mod acknowledgment {
 
         assert!(result.is_err(), "Invalid receipt should return error");
         match result.unwrap_err() {
-            QueueError::MessageNotFound { .. } => {
+            QueueError::InvalidReceipt { .. } => {
                 // Expected error
             }
-            other => panic!("Expected MessageNotFound, got {:?}", other),
+            other => panic!("Expected InvalidReceipt, got {:?}", other),
         }
     }
 

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -10,7 +10,7 @@ pub mod nats;
 pub mod rabbitmq;
 
 pub use aws::{AwsError, AwsSessionProvider, AwsSqsProvider};
-pub use azure::{AzureAuthMethod, AzureServiceBusProvider, AzureSessionProvider};
+pub use azure::{AzureAuthMethod, AzureError, AzureServiceBusProvider, AzureSessionProvider};
 pub use memory::{InMemoryProvider, InMemorySessionProvider};
 pub use nats::{NatsError, NatsProvider, NatsSessionProvider};
 pub use rabbitmq::{RabbitMqError, RabbitMqProvider, RabbitMqSessionProvider};

--- a/src/providers/rabbitmq_tests.rs
+++ b/src/providers/rabbitmq_tests.rs
@@ -162,7 +162,7 @@ mod header_tests {
     /// Verify that TTL is encoded as expiration property.
     #[test]
     fn test_ttl_encoded_as_expiration() {
-        let message = Message::new(bytes::Bytes::from("body")).with_ttl(Duration::seconds(60));
+        let message = Message::new(bytes::Bytes::from("body")).with_time_to_live(Duration::seconds(60));
 
         let props = RabbitMqProvider::build_properties(&message);
         let expiration = props.expiration().as_ref().map(|s| s.to_string());
@@ -293,7 +293,7 @@ mod header_tests {
     /// Verify that TTL of zero does not set an expiration property.
     #[test]
     fn test_zero_ttl_not_encoded() {
-        let message = Message::new(bytes::Bytes::from("body")).with_ttl(Duration::seconds(0));
+        let message = Message::new(bytes::Bytes::from("body")).with_time_to_live(Duration::seconds(0));
         let props = RabbitMqProvider::build_properties(&message);
         let expiration = props.expiration().as_ref().map(|s| s.to_string());
         assert!(expiration.is_none(), "Zero TTL should not set expiration");

--- a/src/providers/rabbitmq_tests.rs
+++ b/src/providers/rabbitmq_tests.rs
@@ -162,7 +162,8 @@ mod header_tests {
     /// Verify that TTL is encoded as expiration property.
     #[test]
     fn test_ttl_encoded_as_expiration() {
-        let message = Message::new(bytes::Bytes::from("body")).with_time_to_live(Duration::seconds(60));
+        let message =
+            Message::new(bytes::Bytes::from("body")).with_time_to_live(Duration::seconds(60));
 
         let props = RabbitMqProvider::build_properties(&message);
         let expiration = props.expiration().as_ref().map(|s| s.to_string());
@@ -293,7 +294,8 @@ mod header_tests {
     /// Verify that TTL of zero does not set an expiration property.
     #[test]
     fn test_zero_ttl_not_encoded() {
-        let message = Message::new(bytes::Bytes::from("body")).with_time_to_live(Duration::seconds(0));
+        let message =
+            Message::new(bytes::Bytes::from("body")).with_time_to_live(Duration::seconds(0));
         let props = RabbitMqProvider::build_properties(&message);
         let expiration = props.expiration().as_ref().map(|s| s.to_string());
         assert!(expiration.is_none(), "Zero TTL should not set expiration");


### PR DESCRIPTION
Resolves several API shape inconsistencies and a spec/code mismatch identified in a usability review of the public crate surface, covering error types, re-exports, naming, and serialization safety.

## What Changed

- **`QueueError::InvalidReceipt`** — new variant added to `error.rs` to distinguish invalid or expired receipt handles from `MessageNotFound`. All AWS and Azure provider code paths that previously returned `MessageNotFound` for bad/expired handles now return `InvalidReceipt`.
- **AWS and Azure re-exports** — `AwsError`, `AwsSqsProvider`, `AwsSessionProvider`, and `AzureError` are now re-exported from `providers/mod.rs` and `lib.rs`, consistent with every other provider type.
- **`SendOptions`/`ReceiveOptions` removed from crate root** — neither type is accepted by any current public API method; re-exporting them misled callers into thinking they could be used.
- **`Message::with_ttl` renamed to `with_time_to_live`** — aligns with the identical method on `SendOptions` so the same concept has one name.
- **`SessionSupport::Unsupported` removed** — no provider returns this variant; it inflated the API surface and created false expectations for match arms.
- **`AwsSqsConfig::secret_access_key` marked `#[serde(skip)]`** — prevents the AWS secret key from being emitted in plain text when a `QueueConfig` is serialized (mirrors the existing `AzureAuthMethod` approach).
- **Cross-reference doc comments** — `QueueClient::receive_message` and `accept_session` now each point to the other with a `# Note` section to guide users to the correct API for their ordering requirements.

## Why

A usability review (`spec-feedback.md`) identified four major and three minor issues with the public API:

- `InvalidReceipt` was referenced in the spec (`docs/spec/assertions.md` assertion #6, `docs/spec/architecture.md`) but the variant did not exist, making it impossible to write spec-conformant tests.
- AWS types were inaccessible at the crate root, forcing users to reach into the internal module path (`queue_runtime::providers::AwsError`) unlike every other provider.
- `AzureError` was similarly missing from `providers/mod.rs` despite being used in tests.
- `SendOptions`/`ReceiveOptions` being re-exported but unusable was a misleading dead end for callers.
- `with_ttl` and `with_time_to_live` naming inconsistency created friction when moving between `Message` and `SendOptions`.
- `SessionSupport::Unsupported` had no reachable production code paths.
- `secret_access_key` was serializable in plain text, a security concern absent from every other credential field in the codebase.

## How

- Added `InvalidReceipt { receipt: String }` to `QueueError` and updated `is_transient` / `retry_after` to handle it (non-transient, no retry delay).
- Mapped `AwsError::InvalidReceipt` → `QueueError::InvalidReceipt` and updated all inline `MessageNotFound` returns in AWS/Azure provider methods that check receipt handle format or respond to HTTP 410 GONE / 404 NOT FOUND on lock operations.
- Updated `providers/mod.rs` to re-export `AzureError` alongside the existing Azure types; extended the `pub use providers::{...}` block in `lib.rs` to include all six previously-missing types.
- Removed `SendOptions` and `ReceiveOptions` from the `pub use message::{...}` block in `lib.rs` (types remain usable via the `message` module path for future API evolution).
- Renamed `Message::with_ttl` → `with_time_to_live` in `message.rs` and updated all six call sites across test files.
- Removed `SessionSupport::Unsupported` from `provider.rs` and narrowed the `matches!` guard in `client_tests.rs`.
- Added `#[serde(skip)]` to `AwsSqsConfig::secret_access_key`; field value must now be supplied at runtime (consistent with `AzureAuthMethod::ClientSecret` which is already skipped).

## Testing Evidence

- **Test Coverage:** Updated tests in `aws_tests.rs`, `azure_tests.rs`, `client_tests.rs`, `memory_tests.rs`, and `rabbitmq_tests.rs` to reflect renamed methods, corrected error variants (`InvalidReceipt` instead of `MessageNotFound`), and removal of `SessionSupport::Unsupported` from match arms.
- **Test Results:** All 334 unit tests pass with zero failures (`cargo test`).
- **Manual Testing:** `cargo check` confirmed clean compilation with no errors; pre-existing dead-code and `assert!(true)` warnings in `aws_tests.rs` are unrelated to this change.

## Reviewer Guidance

- **Breaking changes:** `Message::with_ttl` is renamed to `with_time_to_live` — any caller outside this crate using that method will need updating. `SessionSupport::Unsupported` is removed — any external `match` on `SessionSupport` will need to drop that arm. `SendOptions` and `ReceiveOptions` are no longer re-exported from the crate root (still accessible via `queue_runtime::message::SendOptions`).
- **`AwsSqsConfig::secret_access_key` serde skip:** callers who were round-tripping a `QueueConfig` through serialization and relying on the key being preserved must now supply it separately. Verify this is acceptable for any config-management use cases.
- **`QueueError::InvalidReceipt` vs `MessageNotFound`:** review the provider-level call sites to confirm the semantic distinction is applied consistently — `InvalidReceipt` for bad/expired handles, `MessageNotFound` for genuinely absent messages.
- **Re-export additions:** `AzureError`, `AwsError`, `AwsSqsProvider`, `AwsSessionProvider` are now part of the stable public API surface; confirm the semver implications are acceptable before merging.