### PR TITLE
fix(cliff): remove typos preprocessor that breaks release-plz version detection

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -65,9 +65,6 @@ split_commits = false
 # regex for preprocessing the commit messages
 commit_preprocessors = [
     { pattern = '\((\w+\s)?#([0-9]+)\)', replace = "([#${2}](<REPO>/issues/${2}))" },
-    # Check spelling of the commit with https://github.com/crate-ci/typos
-    # If the spelling is incorrect, it will be automatically fixed.
-    { pattern = '.*', replace_command = 'typos --write-changes -' },
 ]
 # regex for parsing and grouping commits
 commit_parsers = [


### PR DESCRIPTION
The typos spell-checker preprocessor caused all commits to fail parsing in the release-plz CI environment where typos is not installed. This resulted in git-cliff reporting zero changelog entries, causing release-plz to fall back to cargo-semver-checks alone, which only detected a patch bump (0.1.1) instead of the correct minor bump (0.2.0) driven by feat: commits.

Spell checking belongs in pre-commit hooks, not in changelog generation.