### PR TITLE
fix(changelog): Add remote.github section to cliff.toml

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -50,6 +50,10 @@ footer = """
 # remove the leading and trailing whitespace from the templates
 trim = true
 
+[remote.github]
+owner = "pvandervelde"
+repo = "queue-runtime"
+
 # postprocessors
 postprocessors = [
     { pattern = '<REPO>', replace = "https://github.com/pvandervelde/queue-runtime" }, # replace repository URL


### PR DESCRIPTION
The footer template in cliff.toml references `remote.github.owner` and `remote.github.repo` but these variables were not defined, causing the release-plz PR workflow to fail with:

    Variable remote.github.owner not found in context while rendering 'footer'