### PR TITLE
fix(cliff): hardcode github owner/repo in footer template

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -32,14 +32,14 @@ footer = """
         {% if release.previous -%}
             {% if release.previous.version -%}
                 [{{ release.version | trim_start_matches(pat="v") }}]: \
-                    https://github.com/{{ remote.github.owner }}/{{ remote.github.repo }}\
+                    https://github.com/pvandervelde/queue-runtime\
                         /compare/{{ release.previous.version }}..{{ release.version }}
             {% endif -%}
         {% endif -%}
     {% else -%}
         {% if release.previous -%}
             {% if release.previous.version -%}
-                [unreleased]: https://github.com/{{ remote.github.owner }}/{{ remote.github.repo }}\
+                [unreleased]: https://github.com/pvandervelde/queue-runtime\
                     /compare/{{ release.previous.version }}..HEAD
             {% endif -%}
         {% endif -%}


### PR DESCRIPTION
## Summary

release-plz does not inject the \emote.github\ context when calling git-cliff internally. This caused the changelog footer template to fail during the release-plz PR workflow with:

\\\
Variable \emote.github.owner\ not found in context while rendering 'footer'
\\\

## Fix

Replaced \{{ remote.github.owner }}\ and \{{ remote.github.repo }}\ template variables in the \ooter\ section of \cliff.toml\ with hardcoded values (\pvandervelde/queue-runtime\). The \[remote.github]\ section is retained as it is still used by git-cliff when run directly (e.g. for PR/issue linking).