### PR TITLE
fix(cliff): add [bump] section to ensure feat commits trigger minor version bump

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -1,6 +1,13 @@
 # git-cliff ~ configuration file
 # https://git-cliff.org/docs/configuration
 
+[bump]
+# Always bump minor for feat commits, even on 0.x.y versions.
+# Without this, git-cliff defaults features_always_bump_minor=false, which
+# treats feat as a patch bump when major version is 0.
+features_always_bump_minor = true
+breaking_always_bump_major = true
+
 [changelog]
 # template for the changelog footer
 header = """


### PR DESCRIPTION
## Problem

release-plz was proposing v0.1.1 (patch) instead of v0.2.0 (minor) despite two new features being merged since v0.1.0.

## Root Cause

\cliff.toml\ was missing a \[bump]\ section. git-cliff's \eatures_always_bump_minor\ defaults to \alse\, and when \alse\ and the major version is 0, git-cliff treats \eat:\ commits as **patch-level** bumps. This meant release-plz saw only patch-worthy changes and proposed 0.1.1.

## Fix

Added a \[bump]\ section to \cliff.toml\ with:
- \eatures_always_bump_minor = true\ — \eat:\ commits always trigger a minor bump, regardless of major version being 0
- \reaking_always_bump_major = true\ — breaking changes always trigger a major bump

## After This Merges

The stale \elease-plz-2026-02-08T12-07-56Z\ branch/PR should be closed and release-plz re-run. It will then propose v0.2.0.