### PR TITLE
ci(release-plz): add workflow_dispatch trigger to release-plz PR workflow

### DIFF
--- a/.github/workflows/release-plz-pr.yml
+++ b/.github/workflows/release-plz-pr.yml
@@ -4,6 +4,7 @@ on:
     push:
         branches:
             - master
+    workflow_dispatch: {}
 
 # Prevent concurrent runs from creating duplicate or conflicting PRs.
 concurrency:


### PR DESCRIPTION
## Problem

The release-plz PR workflow only triggers on \push\ to master. When a branch is deleted before the push-triggered run completes (or the run is missed), there is no way to manually re-trigger it.

## Fix

Add \workflow_dispatch: {}\ so the workflow can be triggered manually from the GitHub Actions UI.

## Usage After Merge

Go to **Actions → Release-plz PR → Run workflow** to manually kick off a new release-plz PR.