### PR TITLE
fix(release-plz): set features_always_increment_minor to produce v0.2.0

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -28,3 +28,7 @@ publish_allow_dirty = false
 
 # disable running `cargo-semver-checks`
 semver_check = true
+
+# always bump minor version for feat commits, even in 0.x releases
+# (by default, release-plz only bumps minor starting with 1.x)
+features_always_increment_minor = true


### PR DESCRIPTION
## Problem

release-plz continues to propose v0.1.1 despite two \eat\ commits since v0.1.0.

## Root Cause

The \cliff.toml\ \[bump]\ section (added in #31) only controls how the \git cliff\ CLI bumps versions. **release-plz has its own separate version bump logic** — it does not read the cliff.toml \[bump]\ section.

release-plz's \eatures_always_increment_minor\ defaults to \alse\, which means \eat:\ commits only bump the minor version for 1.x+. For 0.x packages, features are treated as patch bumps by default, hence 0.1.1.

## Fix

Add \eatures_always_increment_minor = true\ to \elease-plz.toml\. This tells release-plz itself to treat \eat\ commits as minor bumps regardless of the major version being 0.

## After Merging

Close the stale \elease-plz-2026-04-21T11-54-11Z\ PR and re-run the **Release-plz PR** workflow manually (Actions → Release-plz PR → Run workflow). It should now propose v0.2.0.